### PR TITLE
Use pipe syntax for optional types with typer

### DIFF
--- a/adventofcode/main.py
+++ b/adventofcode/main.py
@@ -4,7 +4,7 @@ import pathlib
 import sys
 import time
 from dataclasses import dataclass
-from typing import Any, Callable, Iterable, Optional
+from typing import Any, Callable, Iterable
 
 import joblib
 import typer
@@ -17,8 +17,8 @@ app = typer.Typer()
 
 @app.command()
 def main(
-    day: Annotated[Optional[int], typer.Argument()] = None,
-    problem: Annotated[Optional[int], typer.Argument()] = None,
+    day: Annotated[int | None, typer.Argument()] = None,
+    problem: Annotated[int | None, typer.Argument()] = None,
     verbosity: Annotated[
         int,
         typer.Option(

--- a/poetry.lock
+++ b/poetry.lock
@@ -462,13 +462,13 @@ files = [
 
 [[package]]
 name = "typer"
-version = "0.12.3"
+version = "0.12.4"
 description = "Typer, build great CLIs. Easy to code. Based on Python type hints."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "typer-0.12.3-py3-none-any.whl", hash = "sha256:070d7ca53f785acbccba8e7d28b08dcd88f79f1fbda035ade0aecec71ca5c914"},
-    {file = "typer-0.12.3.tar.gz", hash = "sha256:49e73131481d804288ef62598d97a1ceef3058905aa536a1134f90891ba35482"},
+    {file = "typer-0.12.4-py3-none-any.whl", hash = "sha256:819aa03699f438397e876aa12b0d63766864ecba1b579092cc9fe35d886e34b6"},
+    {file = "typer-0.12.4.tar.gz", hash = "sha256:c9c1613ed6a166162705b3347b8d10b661ccc5d95692654d0fb628118f2c34e6"},
 ]
 
 [package.dependencies]
@@ -491,4 +491,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "8ffb39b1fb73f2f2156f46cebef460596aa98fc2e3143afe576c9c0c9a866f53"
+content-hash = "6b985b30e2d8ecfbcee7aec2f29cd0ecb660e0d0689d279d569a1fa9c300b1ba"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ validate = ["lint", "test", "runall"]
 
 [tool.poetry.dependencies]
 python = "^3.12"
-typer = "^0.12.3"
+typer = "^0.12.4"
 joblib = "^1.4.2"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
Newest version 0.12.4 of typer added support for specifying the types
of command line argument parameters using the pipe syntax instead of
using Optional[]. This commit updates typer and updates the code to use
the newer coding style.