### PR TITLE
Use PEP-696 syntax for default generic type

### DIFF
--- a/adventofcode/tooling/map.py
+++ b/adventofcode/tooling/map.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import enum
-from typing import TYPE_CHECKING, Generic, Literal, TypeVar, assert_never, overload
+from typing import TYPE_CHECKING, Literal, assert_never, overload
 
 from .coordinates import X, Y
 from .directions import RotationDirection
@@ -25,10 +25,7 @@ class IterDirection(enum.Enum):
     Columns = enum.auto()
 
 
-Map2dDataType = TypeVar("Map2dDataType", default=str)
-
-
-class Map2d(Generic[Map2dDataType]):
+class Map2d[Map2dDataType = str]:
     __slots__ = ("_br_x", "_br_y", "_height", "_sequence_data", "_width")
 
     def __init__(


### PR DESCRIPTION
Mypy 1.14 adds support for the new syntax.