### PR TITLE
Fix pyright CI workflow PR trigger paths

### DIFF
--- a/.github/workflows/check-pyright.yaml
+++ b/.github/workflows/check-pyright.yaml
@@ -2,9 +2,16 @@ name: Check - pyright
 
 on:
   pull_request:
-    paths-ignore:
+    paths:
       - "**.py"
       - "**/py.typed"
+      - ".github/actions/uv-project-setup/**"
+      - ".github/actions/yarn-project-setup/**"
+      - ".github/workflows/check-pyright.yaml"
+      - "package.json"
+      - "pyproject.toml"
+      - "uv.lock"
+      - "yarn.lock"
   workflow_call:
   workflow_dispatch:
 


### PR DESCRIPTION
Previously the paths were apparently copied from prettier workflow file which had the opposite effect of what was desired: no python file change triggered pyright checks but changing any other file did. This commit fixes the paths that trigger pyright workflow for pull requests.