### PR TITLE
ci: Use node version specified in package.json

### DIFF
--- a/.github/actions/yarn-project-setup/action.yaml
+++ b/.github/actions/yarn-project-setup/action.yaml
@@ -9,7 +9,7 @@ runs:
     - name: Setup node
       uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4
       with:
-        node-version: 22
+        node-version-file: package.json
         cache: yarn
     - name: Install yarn dev tools
       run: yarn install --immutable


### PR DESCRIPTION
Let CI use the same node version as is specified in package.json as compatible node engine version.