### PR TITLE
Use latest renovate for config validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "check:yarn:dedupe": "yarn dedupe --check",
     "check:prettier": "prettier --check .",
     "check:pyright": "pyright",
-    "check:renovateconfig": "npx --package=renovate --yes -- renovate-config-validator --strict",
+    "check:renovateconfig": "npx --package=renovate@latest --yes --prefer-online renovate-config-validator --strict",
     "fix:prettier": "prettier --write --cache-location .prettiercache ."
   },
   "private": true,


### PR DESCRIPTION
Previously the npx command used wasn't explicitly setting the version of renovate package used to be latest stable version. Instead npx picked 37.440.7 locally. Why that version got picked up isn't known, but setting explicitly to latest tag fixes the problem.